### PR TITLE
CCM-5680 Support dedicated dev envs

### DIFF
--- a/infrastructure/terraform/components/branch/module_amplify_branch.tf
+++ b/infrastructure/terraform/components/branch/module_amplify_branch.tf
@@ -13,6 +13,6 @@ module "amplify_branch" {
   cognito_user_pool_identity_provider_names = local.iam.cognito_user_pool["identity_providers"]
   amplify_app_id                            = local.iam.amplify["id"]
   branch                                    = var.branch_name
-  domain_name                               = local.acct.dns_zone["name"]
+  domain_name                               = local.dns_prefix
   subdomain                                 = var.environment
 }

--- a/infrastructure/terraform/components/iam/amplify_app.tf
+++ b/infrastructure/terraform/components/iam/amplify_app.tf
@@ -16,9 +16,9 @@ resource "aws_amplify_app" "main" {
 
   environment_variables = {
     USER_POOL_ID = aws_cognito_user_pool.main.id
-    # HOSTED_LOGIN_DOMAIN = "auth.${local.acct.dns_zone["name"]}"
+    # HOSTED_LOGIN_DOMAIN = "auth.${local.dns_prefix}"
     NOTIFY_GROUP       = var.group
     NOTIFY_ENVIRONMENT = var.environment
-    NOTIFY_DOMAIN_NAME = local.acct.dns_zone["name"]
+    NOTIFY_DOMAIN_NAME = local.dns_prefix
   }
 }

--- a/infrastructure/terraform/components/iam/amplify_domain_association.tf
+++ b/infrastructure/terraform/components/iam/amplify_domain_association.tf
@@ -1,6 +1,6 @@
 # resource "aws_amplify_domain_association" "domain" {
 #   app_id                 = aws_amplify_app.main.id
-#   domain_name            = local.acct.dns_zone["name"]
+#   domain_name            = local.dns_prefix
 #   enable_auto_sub_domain = true
 
 #   sub_domain {
@@ -20,7 +20,7 @@ resource "null_resource" "amplify_domain_association" {
   triggers = {
     amplify_app_id      = aws_amplify_app.main.id
     amplify_branch_name = module.amplify_branch.name
-    amplify_domain_name = local.acct.dns_zone["name"]
+    amplify_domain_name = local.dns_prefix
   }
 
   provisioner "local-exec" {

--- a/infrastructure/terraform/components/iam/locals.tf
+++ b/infrastructure/terraform/components/iam/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  dns_prefix = "${var.environment}.${local.acct.dns_zone["name"]}"
+}

--- a/infrastructure/terraform/components/iam/locals_remote_state.tf
+++ b/infrastructure/terraform/components/iam/locals_remote_state.tf
@@ -32,7 +32,7 @@ data "terraform_remote_state" "acct" {
       var.project,
       var.aws_account_id,
       "eu-west-2",
-      var.environment
+      var.parent_acct_environment
     )
 
     region = "eu-west-2"

--- a/infrastructure/terraform/components/iam/module_amplify_branch.tf
+++ b/infrastructure/terraform/components/iam/module_amplify_branch.tf
@@ -13,7 +13,7 @@ module "amplify_branch" {
   cognito_user_pool_identity_provider_names = aws_cognito_user_pool_client.main.supported_identity_providers
   amplify_app_id                            = aws_amplify_app.main.id
   branch                                    = "main"
-  domain_name                               = local.acct.dns_zone["name"]
+  domain_name                               = local.dns_prefix
   subdomain                                 = var.environment
   enable_auto_deploy                        = true
 }

--- a/infrastructure/terraform/components/iam/variables.tf
+++ b/infrastructure/terraform/components/iam/variables.tf
@@ -69,6 +69,11 @@ variable "root_domain_name" {
   default     = "nonprod.nhsnotify.national.nhs.uk"
 }
 
+variable "parent_acct_environment" {
+  type        = string
+  description = "Name of the environment responsible for the acct resources used, affects things like DNS zone. Useful for named dev environments"
+  default     = "main"
+}
 variable "enable_amplify_branch_auto_build" {
   type        = bool
   description = "Enable automatic building of branches"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Support dedicated developer environments through a prefix on Route53 records.
Adds a prefix override to allow switching the parent ACCT component, namely the DNS zone so that the .dev.nhsnotify.national.nhs.uk namespace can be selected though the [documentation](https://nhsd-confluence.digital.nhs.uk/display/RIS/NHS+Notify+%7C+Web+UI+%7C+Mapping+DNS+names+to+MFE+deployments) doesnt seem to use this zone at present. 

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
