### PR TITLE
CCM-7908 adding mechanism for TFVAR based secret

### DIFF
--- a/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
@@ -1,7 +1,9 @@
 resource "aws_ssm_parameter" "amplify_password" {
   count = var.enable_amplify_basic_auth ? 1 : 0
 
-  name  = "/${local.csi}/amplify_password"
+  name        = "/${local.csi}/amplify_password"
+  description = "The Basic Auth password used for the amplify app. This parameter is sourced from Github Environment variables"
+
   type  = "String"
   value = var.amplify_basic_auth_secret != "unset" ? var.amplify_basic_auth_secret : random_password.password[0].result
 }

--- a/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
@@ -3,7 +3,7 @@ resource "aws_ssm_parameter" "amplify_password" {
 
   name  = "/${local.csi}/amplify_password"
   type  = "String"
-  value = var.amplify_basic_auth_secret != "unset" ?  var.amplify_basic_auth_secret : random_password.password[0].result
+  value = var.amplify_basic_auth_secret != "unset" ? var.amplify_basic_auth_secret : random_password.password[0].result
 }
 
 resource "random_password" "password" {

--- a/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
@@ -5,11 +5,11 @@ resource "aws_ssm_parameter" "amplify_password" {
   description = "The Basic Auth password used for the amplify app. This parameter is sourced from Github Environment variables"
 
   type  = "String"
-  value = var.amplify_basic_auth_secret != "unset" ? var.amplify_basic_auth_secret : random_password.password[0].result
+  value = var.AMPLIFY_BASIC_AUTH_SECRET != "unset" ? var.AMPLIFY_BASIC_AUTH_SECRET : random_password.password[0].result
 }
 
 resource "random_password" "password" {
-  count = var.enable_amplify_basic_auth && var.amplify_basic_auth_secret == "unset" ? 1 : 0
+  count = var.enable_amplify_basic_auth && var.AMPLIFY_BASIC_AUTH_SECRET == "unset" ? 1 : 0
 
   length  = 16
   special = true

--- a/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
+++ b/infrastructure/terraform/components/app/ssm_parameter_amplify_password.tf
@@ -3,11 +3,11 @@ resource "aws_ssm_parameter" "amplify_password" {
 
   name  = "/${local.csi}/amplify_password"
   type  = "String"
-  value = random_password.password[0].result
+  value = var.amplify_basic_auth_secret != "unset" ?  var.amplify_basic_auth_secret : random_password.password[0].result
 }
 
 resource "random_password" "password" {
-  count = var.enable_amplify_basic_auth ? 1 : 0
+  count = var.enable_amplify_basic_auth && var.amplify_basic_auth_secret == "unset" ? 1 : 0
 
   length  = 16
   special = true

--- a/infrastructure/terraform/components/app/variables.tf
+++ b/infrastructure/terraform/components/app/variables.tf
@@ -93,10 +93,10 @@ variable "enable_amplify_basic_auth" {
   default     = true
 }
 
-variable "amplify_basic_auth_secret" {
+variable "AMPLIFY_BASIC_AUTH_SECRET" {
+  # Github only does uppercase env vars
   type        = string
   description = "Secret key/password to use for Amplify Basic Auth - This is entended to be read from CI variables and not commited to any codebase"
-  sensitive   = true
   default     = "unset"
 }
 

--- a/infrastructure/terraform/components/app/variables.tf
+++ b/infrastructure/terraform/components/app/variables.tf
@@ -90,7 +90,14 @@ variable "enable_cognito_built_in_idp" {
 variable "enable_amplify_basic_auth" {
   type        = bool
   description = "Enable a basic set of credentials in the form of a dynamically generated username and password for the amplify app branches. Not intended for production use"
-  default     = false
+  default     = true
+}
+
+variable "amplify_basic_auth_secret" {
+  type        = string
+  description = "Secret key/password to use for Amplify Basic Auth - This is entended to be read from CI variables and not commited to any codebase"
+  sensitive   = true
+  default     = "unset"
 }
 
 variable "branch_name" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds a mechanism by which the authorization headers for the three microservices can be set consistently so that communication between auth, templates and the gateway can be centrally managed per

TF_VAR_amplify_basic_auth_secret is set on the internal repo already, merging this will cause access to be limited while the CDN, IAM-Webauth, and Web-Templates are deployed  and pick this up

<!-- Describe your changes in detail. -->

## Context
[TDA-2024-03](https://nhsd-confluence.digital.nhs.uk/pages/viewpage.action?spaceKey=RIS&title=TDA-2024-03)

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
