### PR TITLE
CCM-5340: Add CSP header with nonce for next generated inline scripts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ module.exports = {
 
   experimental: {
     serverActions: {
-      allowedOrigins: allowedOrigins,
+      allowedOrigins,
     },
   },
 

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -4,16 +4,63 @@
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
 
-const cspRegex =
-  /^base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self'; font-src 'self' https:\/\/assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-[\dA-Za-z]+'; style-src 'self'; upgrade-insecure-requests$/;
+const OLD_ENV = { ...process.env };
+afterAll(() => {
+  process.env = OLD_ENV;
+});
+
+function getCsp() {
+  const url = new URL('https://main.web-gateway.dev.nhsnotify.national.nhs.uk');
+  const request = new NextRequest(url);
+  const response = middleware(request);
+  const csp = response.headers.get('Content-Security-Policy');
+  return csp?.split(';').map((s) => s.trim());
+}
 
 describe('middleware function', () => {
   it('sets CSP in response', () => {
-    const request = new NextRequest(
-      new URL('https://main.web-gateway.dev.nhsnotify.national.nhs.uk')
-    );
-    const response = middleware(request);
-    const csp = response.headers.get('Content-Security-Policy');
-    expect(csp).toMatch(cspRegex);
+    // @ts-expect-error assignment to readonly
+    process.env.NODE_ENV = 'production';
+
+    expect(getCsp()).toEqual([
+      "base-uri 'self'",
+      "default-src 'none'",
+      "frame-ancestors 'none'",
+      "font-src 'self' https://assets.nhs.uk",
+      "form-action 'self'",
+      "frame-src 'self'",
+      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com",
+      "img-src 'self'",
+      "manifest-src 'self'",
+      "object-src 'none'",
+      expect.stringMatching(/^script-src 'self' 'nonce-[\dA-Za-z]+'$/),
+      "style-src 'self' 'unsafe-inline'",
+      'upgrade-insecure-requests',
+      '',
+    ]);
+  });
+
+  it('sets CSP in response in dev mode, including unsafe-eval scripts to allow for source maps', () => {
+    // @ts-expect-error assignment to readonly
+    process.env.NODE_ENV = 'development';
+
+    expect(getCsp()).toEqual([
+      "base-uri 'self'",
+      "default-src 'none'",
+      "frame-ancestors 'none'",
+      "font-src 'self' https://assets.nhs.uk",
+      "form-action 'self'",
+      "frame-src 'self'",
+      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com",
+      "img-src 'self'",
+      "manifest-src 'self'",
+      "object-src 'none'",
+      expect.stringMatching(
+        /^script-src 'self' 'nonce-[\dA-Za-z]+' 'unsafe-eval'$/
+      ),
+      "style-src 'self' 'unsafe-inline'",
+      'upgrade-insecure-requests',
+      '',
+    ]);
   });
 });

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -4,6 +4,12 @@
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
 
+jest.mock('../utils/public-constants', () => ({
+  getConstants: () => ({
+    COGNITO_DOMAIN: 'auth.env.iam.dev.nhsnotify.national.nhs.uk',
+  }),
+}));
+
 const OLD_ENV = { ...process.env };
 afterAll(() => {
   process.env = OLD_ENV;
@@ -29,7 +35,7 @@ describe('middleware function', () => {
       "font-src 'self' https://assets.nhs.uk",
       "form-action 'self'",
       "frame-src 'self'",
-      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com",
+      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com https://auth.env.iam.dev.nhsnotify.national.nhs.uk/oauth2/token",
       "img-src 'self'",
       "manifest-src 'self'",
       "object-src 'none'",
@@ -51,7 +57,7 @@ describe('middleware function', () => {
       "font-src 'self' https://assets.nhs.uk",
       "form-action 'self'",
       "frame-src 'self'",
-      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com",
+      "connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com https://auth.env.iam.dev.nhsnotify.national.nhs.uk/oauth2/token",
       "img-src 'self'",
       "manifest-src 'self'",
       "object-src 'none'",

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
 

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import { middleware } from '../middleware';
+
+const cspRegex =
+  /^base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self'; font-src 'self' https:\/\/assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-[\dA-Za-z]+'; style-src 'self'; upgrade-insecure-requests$/;
+
+describe('middleware function', () => {
+  it('sets CSP in response', () => {
+    const request = new NextRequest(
+      new URL('https://main.web-gateway.dev.nhsnotify.national.nhs.uk')
+    );
+    const response = middleware(request);
+    const csp = response.headers.get('Content-Security-Policy');
+    expect(csp).toMatch(cspRegex);
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import content from '@/src/content/content';
 import { ClientLayout } from '@/src/components/molecules/ClientLayout/ClientLayout';
 import 'nhsuk-frontend/dist/nhsuk.css';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: content.global.mainLayout.title,
   description: content.global.mainLayout.description,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
-  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self'; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self'; upgrade-insecure-requests`;
+
+  const cspUnsafeEval =
+    process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
+
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
@@ -18,3 +22,22 @@ export function middleware(request: NextRequest) {
 
   return response;
 }
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ function getContentSecurityPolicy(nonce: string) {
     'img-src': [`'self'`],
     'manifest-src': [`'self'`],
     'object-src': [`'none'`],
-    'script-src': [`'self'`, `'nonce-${nonce}'`, `'strict-dynamic'`],
+    'script-src': [`'self'`, `'nonce-${nonce}'`],
     'style-src': [`'self'`, `'nonce-${nonce}'`],
     'upgrade-insecure-requests;': [],
   };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,11 @@ export function middleware(request: NextRequest) {
 
   requestHeaders.set('Content-Security-Policy', csp);
 
+  // requestHeaders.set(
+  //   'x-forwarded-host',
+  //   requestHeaders.get('origin')?.replace('https://', '') || '*'
+  // );
+
   const response = NextResponse.next({
     request: {
       headers: requestHeaders,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ export function middleware(request: NextRequest) {
   const cspUnsafeEval =
     process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
 
-  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval} 'strict-dynamic'; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,11 @@ function getContentSecurityPolicy(nonce: string) {
     'font-src': [`'self'`, 'https://assets.nhs.uk'],
     'form-action': [`'self'`],
     'frame-src': [`'self'`],
-    'connect-src': [`'self'`, 'https://cognito-idp.eu-west-2.amazonaws.com'],
+    'connect-src': [
+      `'self'`,
+      'https://cognito-idp.eu-west-2.amazonaws.com',
+      'https://nhs-notify-975050048865-eu-west-2-alnu1-app.auth.eu-west-2.amazoncognito.com/oauth2/token',
+    ],
     'img-src': [`'self'`],
     'manifest-src': [`'self'`],
     'object-src': [`'none'`],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getConstants } from './utils/public-constants';
+
+const { COGNITO_DOMAIN } = getConstants();
 
 function getContentSecurityPolicy(nonce: string) {
   const contentSecurityPolicyDirective = {
@@ -11,7 +14,7 @@ function getContentSecurityPolicy(nonce: string) {
     'connect-src': [
       `'self'`,
       'https://cognito-idp.eu-west-2.amazonaws.com',
-      'https://nhs-notify-975050048865-eu-west-2-alnu1-app.auth.eu-west-2.amazoncognito.com/oauth2/token',
+      `https://${COGNITO_DOMAIN}/oauth2/token`,
     ],
     'img-src': [`'self'`],
     'manifest-src': [`'self'`],

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,7 @@ function getContentSecurityPolicy(nonce: string) {
     'manifest-src': [`'self'`],
     'object-src': [`'none'`],
     'script-src': [`'self'`, `'nonce-${nonce}'`],
-    'style-src': [`'self'`, `'nonce-${nonce}'`],
+    'style-src': [`'self'`, `'unsafe-inline'`],
     'upgrade-insecure-requests;': [],
   };
 
@@ -52,8 +52,7 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    {
-      source: '/((?!_next/static|_next/image|favicon.ico|lib).*)',
-    },
+    '/',
+    '/((?!_next/static|_next/image|favicon.ico|lib/).*)',
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,6 +51,7 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - lib/ (our static content)
      */
     '/',
     '/((?!_next/static|_next/image|favicon.ico|lib/).*)',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,8 +12,9 @@ function getContentSecurityPolicy(nonce: string) {
     'img-src': [`'self'`],
     'manifest-src': [`'self'`],
     'object-src': [`'none'`],
-    'script-src': [`'nonce-${nonce}'`, `'strict-dynamic'`],
-    'style-src': [`'self'`],
+    'script-src': [`'self'`, `'nonce-${nonce}'`, `'strict-dynamic'`],
+    'style-src': [`'self'`, `'nonce-${nonce}'`],
+    'upgrade-insecure-requests;': [],
   };
 
   if (process.env.NODE_ENV === 'development') {
@@ -31,8 +32,6 @@ export function middleware(request: NextRequest) {
   const csp = getContentSecurityPolicy(nonce);
 
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-nonce', nonce);
-
   requestHeaders.set('Content-Security-Policy', csp);
 
   const response = NextResponse.next({
@@ -54,7 +53,7 @@ export const config = {
      * - favicon.ico (favicon file)
      */
     {
-      source: '/((?!_next/static|_next/image|favicon.ico).*)',
+      source: '/((?!_next/static|_next/image|favicon.ico|lib).*)',
     },
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,17 +27,10 @@ export const config = {
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
-     * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
-      missing: [
-        { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
-      ],
-    },
+    '/((?!_next/static|_next/image|favicon.ico).*)',
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,14 +23,14 @@ export function middleware(request: NextRequest) {
   return response;
 }
 
-export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     */
-    '/((?!_next/static|_next/image|favicon.ico).*)',
-  ],
-};
+// export const config = {
+//   matcher: [
+//     /*
+//      * Match all request paths except for the ones starting with:
+//      * - _next/static (static files)
+//      * - _next/image (image optimization files)
+//      * - favicon.ico (favicon file)
+//      */
+//     '/((?!_next/static|_next/image|favicon.ico).*)',
+//   ],
+// };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,41 +1,36 @@
-// import { NextRequest, NextResponse } from 'next/server';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-// export function middleware(request: NextRequest) {
-//   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
 
-//   const cspUnsafeEval =
-//     process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
+  const cspUnsafeEval =
+    process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
 
-//   const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
-//   const requestHeaders = new Headers(request.headers);
-//   requestHeaders.set('x-nonce', nonce);
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
 
-//   requestHeaders.set('Content-Security-Policy', csp);
+  requestHeaders.set('Content-Security-Policy', csp);
 
-//   const response = NextResponse.next({
-//     request: {
-//       headers: requestHeaders,
-//     },
-//   });
-//   response.headers.set('Content-Security-Policy', csp);
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set('Content-Security-Policy', csp);
 
-//   return response;
-// }
-
-export function middleware() {
-  return NextResponse.next();
+  return response;
 }
 
-// export const config = {
-//   matcher: [
-//     /*
-//      * Match all request paths except for the ones starting with:
-//      * - _next/static (static files)
-//      * - _next/image (image optimization files)
-//      * - favicon.ico (favicon file)
-//      */
-//     '/((?!_next/static|_next/image|favicon.ico).*)',
-//   ],
-// };
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!_next/static|_next/image|favicon.ico).*)',
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,14 +23,21 @@ export function middleware(request: NextRequest) {
   return response;
 }
 
-// export const config = {
-//   matcher: [
-//     /*
-//      * Match all request paths except for the ones starting with:
-//      * - _next/static (static files)
-//      * - _next/image (image optimization files)
-//      * - favicon.ico (favicon file)
-//      */
-//     '/((?!_next/static|_next/image|favicon.ico).*)',
-//   ],
-// };
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self'; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self'; upgrade-insecure-requests`;
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  requestHeaders.set('Content-Security-Policy', csp);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set('Content-Security-Policy', csp);
+
+  return response;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,9 +4,9 @@ export function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
 
   const cspUnsafeEval =
-    process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
+    process.env.NODE_ENV === 'production' ? '' : `http: 'unsafe-eval'`;
 
-  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,31 +1,31 @@
-import { NextRequest, NextResponse } from 'next/server';
+// import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 
-export function middleware(request: NextRequest) {
-  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+// export function middleware(request: NextRequest) {
+//   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
 
-  const cspUnsafeEval =
-    process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
+//   const cspUnsafeEval =
+//     process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
 
-  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
+//   const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set('x-nonce', nonce);
+//   const requestHeaders = new Headers(request.headers);
+//   requestHeaders.set('x-nonce', nonce);
 
-  requestHeaders.set('Content-Security-Policy', csp);
+//   requestHeaders.set('Content-Security-Policy', csp);
 
-  // requestHeaders.set(
-  //   'x-forwarded-host',
-  //   requestHeaders.get('origin')?.replace('https://', '') || '*'
-  // );
+//   const response = NextResponse.next({
+//     request: {
+//       headers: requestHeaders,
+//     },
+//   });
+//   response.headers.set('Content-Security-Policy', csp);
 
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
-  response.headers.set('Content-Security-Policy', csp);
+//   return response;
+// }
 
-  return response;
+export function middleware() {
+  return NextResponse.next();
 }
 
 // export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,7 @@ export function middleware(request: NextRequest) {
   const cspUnsafeEval =
     process.env.NODE_ENV === 'production' ? '' : `'unsafe-eval'`;
 
-  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval}; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
+  const csp = `base-uri 'self'; form-action 'self'; frame-ancestors 'none'; default-src 'none'; connect-src 'self' https://cognito-idp.eu-west-2.amazonaws.com; font-src 'self' https://assets.nhs.uk; img-src 'self'; script-src 'self' 'nonce-${nonce}' https: http: ${cspUnsafeEval} 'strict-dynamic'; style-src 'self' 'nonce-${nonce}'; upgrade-insecure-requests;`;
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds CSP to headers via middleware

## Context

Reflects CSP added to web-gateway at https://github.com/NHSDigital/nhs-notify-web-gateway/pull/41, but nextjs generates inline scripts, so the header needs to be generated at this level so a nonce can be added

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
