### PR TITLE
CCM-8021 disable self-service account recovery

### DIFF
--- a/infrastructure/terraform/components/app/cognito_user_pool.tf
+++ b/infrastructure/terraform/components/app/cognito_user_pool.tf
@@ -7,6 +7,13 @@ resource "aws_cognito_user_pool" "main" {
     allow_admin_create_user_only = true
   }
 
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "admin_only"
+      priority = 1
+    }
+  }
+
   schema {
     name                     = "idassurancelevel"
     attribute_data_type      = "String"

--- a/infrastructure/terraform/components/sandbox/cognito_user_pool.tf
+++ b/infrastructure/terraform/components/sandbox/cognito_user_pool.tf
@@ -6,4 +6,11 @@ resource "aws_cognito_user_pool" "main" {
   admin_create_user_config {
     allow_admin_create_user_only = true
   }
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "admin_only"
+      priority = 1
+    }
+  }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Disable self service account recovery.

## Context

The built in cognito idp will not be used in nonprod and prod environments. In the dev environment, cognito idp will be manually configured by admins. The self service account recovery is therefore not needed. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## Test evidence

Test evidence has been added to [CCM-8021](https://nhsd-jira.digital.nhs.uk/browse/CCM-8021)

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
